### PR TITLE
bump-action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
       - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
Bump a version in the github action so linting stops failing.

https://github.com/cal-itp/big-data-geoanalytics/actions/runs/14522199060/job/40745542744